### PR TITLE
Restructure use cases section

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,30 +172,30 @@
     <section>
       <h2>Use cases</h2>
       <p>
-        This section describes specific use cases for media timed events.
+        Media-timed events carry metadata that is related to points in time,
+        or regions of time on the media timeline, which can be used to trigger
+        retrieval and/or rendering of web resources synchronized with media
+        playback. Such resources can be used to enhance user experience in
+        the context of media that is being rendered. Some examples include
+        display of social media feeds corresponding to a live broadcast such
+        as a sporting event, banner advertisements for sponsored content,
+        accessibility-related assets, such as large print rendering of
+        captions, and display of track titles or images alongside an audio
+        stream.
+      </p>
+      <p>
+        The following sections describe a few use cases in more detail.
       </p>
       <section>
-        <h3>Synchronised event triggering</h3>
+        <h3>MPEG DASH manifest expiry notifications</h3>
         <p>
-          Use cases for media timed events include:
-          <ul>
-            <li>
-              Displaying of images alongside an audio stream. For example, in
-              RadioVIS in DVB, an <code>emsg</code> event contains an image URL,
-              which the user agent requests. In this use case, synchronization of the
-              image rendering to within a second or so is acceptable
-              ([[DVB-DASH]], section 9.1.7). Such image displays may be activated and deactivated
-              at different intervals in the duration of the associated <code>emsg</code> event.
-            </li>
-            <li>
-              Notifying the DASH player Web application that it should refresh
-              its copy of the MPD document ([[MPEGDASH]], section 5.10.4).
-              This is an alternative to setting a cache duration in the HTTP
-              response, so the client can refresh the MPD when it actually
-              changes, and reduces the load on HTTP servers caused by frequent
-              server requests.
-            </li>
-          </ul>
+          Section 5.10.4 of [[MPEGDASH]] describes a DASH specific event that
+          is used to notify a DASH player Web application that it should refresh
+          its copy of the manifest (MPD) document.
+          An in-band <code>emsg</code> event is used an alternative to setting
+          a cache duration in the response to the HTTP request for the manifest,
+          so the client can refresh the MPD when it actually changes, so reducing
+          the load on HTTP servers caused by frequent server requests.
         </p>
         <p>
           Reference: M&amp;E IG call 1 Feb 2018:
@@ -208,10 +208,10 @@
         </p>
       </section>
       <section>
-        <h3>Synchronized rendering of web resources</h3>
+        <h3>Synchronized map animations</h3>
         <p>
           [[WebVMT]] is a format for metadata cues, synchronised with
-          the timed media file, that can drive an online map, e.g., OpenStreetMap,
+          a timed media file, that can drive an online map, e.g., OpenStreetMap,
           rendered in a separate HTML element alongside the media element
           on the web page. The media playhead position controls presentation
           and animation of the map, e.g., pan and zoom, and allows annotations
@@ -231,9 +231,12 @@
           embedded in media containers. Describe a few motivating application
           scenarios.
         </p>
+      </section>
+      <section>
+        <h3>Presentation of auxiliary content in live media</h3>
         <p>
           During a live media presentation, dynamic and unpredictable events
-          may occur which causes temporary suspension of the media presentation.
+          may occur which cause temporary suspension of the media presentation.
           During that suspension interval, auxiliary content such as the presentation
           of UI controls and media files, may be unavailable. Depending on the
           specific user engagement (or not) with the UI controls and the time
@@ -242,30 +245,6 @@
           a multimedia A/V clip along with subtitles corresponding to an
           advertisement, and which were previously downloaded and cached
           by the UA, are played out.
-        </p>
-      </section>
-      <section>
-        <h3>Rendering of Web content embedded in media containers</h3>
-        <p>
-          Media-timed events can be used to trigger retrieval and/or rendering
-          of web resources.  Such resources can be used to enhance user experience
-          in the context of media that is being rendered.  Some examples include
-        <ul>
-          <li>
-            Display of social media feeds corresponding to a live broadcast such as a sporting event.
-          </li>
-          <li>
-            Banner advertisements for sponsored content.
-          </li>
-          <li>
-            Accessibility-related assets, such as large print rendering of captions.
-          </li>
-        </ul>
-        </p>
-        <p class="ednote">
-          Add use case descriptions for rendering of Web content embedded in
-          media containers (e.g., [[WEB-ISOBMFF]]). Describe a few motivating
-          application scenarios.
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -123,6 +123,10 @@
             publisher: "W3C",
             status: "ED",
             date: "11 October 2018"
+          },
+          "HLS-TIMED-METADATA": {
+            title: "Timed Metadata for HTTP Live Streaming",
+            href: "https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/HTTP_Live_Streaming_Metadata_Spec/Introduction/Introduction.html"
           }
         }
       };
@@ -193,6 +197,23 @@
         The following sections describe a few use cases in more detail.
       </p>
       <section>
+        <h3>Audio stream with titles and images</h3>
+        <p>
+          A media content provider wants to provide visual information alongside
+          an audio stream, such as an image of the artist and title of the
+          current playing track, to give users live information about the
+          content they are listening to.
+        </p>
+        <p>
+          Examples include HLS timed metadata [[HLS-TIMED-METADATA]], which uses
+          in-band ID3 metadata to carry the image content, and RadioVIS in DVB
+          ([[DVB-DASH]], section 9.1.7), which defines an in-band event messages
+          that contain image URLs and text messages to be displayed, with
+          information about when the content should be displayed, in relation to
+          the media timeline.
+        </p>
+      </section>
+      <section>
         <h3>MPEG DASH manifest expiry notifications</h3>
         <p>
           Section 5.10.4 of [[MPEGDASH]] describes a DASH specific event that
@@ -231,11 +252,16 @@
           Reference: M&amp;E IG TF call 17 Sept 2018:
           <a href="https://www.w3.org/2018/09/17-me-minutes.html">Minutes</a>.
         </p>
-        <p class="ednote">
-          Add use case descriptions for synchronised rendering here. Note that
-          this could be rendering of any web resource, not necessarily those
-          embedded in media containers. Describe a few motivating application
-          scenarios.
+      </section>
+      <section>
+        <h3>Media analysis visualization</h3>
+        <p>
+          A video image analysis system processes a media stream to detect and
+          recognize objects shown in the videox. This system generates metadata
+          describing the objects, including timestamps that describe the when
+          the objects are visible, together with position information (e.g.,
+          bounding boxes). A web application then uses this timed metadata to
+          overlay labels and annotations on the video using HTML and CSS.
         </p>
       </section>
       <section>


### PR DESCRIPTION
This change reorganises the Use cases section to have a subsection per use case, rather than organising by event triggering, rendering of web resources, and rendering of embedded web resources.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-timed-events/pull/23.html" title="Last updated on Dec 7, 2018, 7:22 PM GMT (5cc6b9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-timed-events/23/ac47dbb...5cc6b9c.html" title="Last updated on Dec 7, 2018, 7:22 PM GMT (5cc6b9c)">Diff</a>