### PR TITLE
Mark definition of "media timed events" as dfn

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
         events synchronized to audio or video media, specifically for both
         <a>out-of-band</a> event streams and <a>in-band</a> discrete events
         (for example, MPD and <code>emsg</code> events in MPEG-DASH).
-        These <dfn data-lt="media timed event">media timed events</dfn> can be used to support use cases
+        These <a>media timed events</a> can be used to support use cases
         such as dynamic content replacement, ad insertion, or presentation of
         supplemental content alongside the audio or video, or more generally,
         making changes to a web page, or executing application code triggered
@@ -103,6 +103,11 @@
         The following terms are used in this document:
       </p>
       <ul>
+        <li>
+          <dfn data-lt="media timed event">media timed events</dfn> &mdash;
+          metadata events synchronized to the <a>media timeline</a> of a
+          <a>media resource</a>.
+        </li>
         <li>
           <dfn>in-band</dfn> &mdash; timed event information that is delivered
           within the audio or video media container or multiplexed with the
@@ -119,7 +124,13 @@
       </p>
       <ul>
         <li>
-          <dfn><a href="https://html.spec.whatwg.org/multipage/media.html#media-timeline">media timeline</a></dfn>
+          <dfn data-cite="HTML/media.html#media-timeline">media timeline</dfn>
+        </li>
+        <li>
+          <dfn data-cite="HTML/media.html#media-resource">media resource</dfn>
+        </li>
+        <li>
+          <dfn data-cite="HTML/media.html#time-marches-on">time marches on</dfn>
         </li>
       </ul>
     </section>
@@ -612,13 +623,12 @@
           <a>media timeline</a>.
         </p>
         <p>
-          The <a href="https://html.spec.whatwg.org/multipage/media.html#time-marches-on"><em>time
-          marches on</em></a> steps in [[HTML]] control the firing of cue
-          events during media playback. <em>Time marches on</em> requires a
+          The <a>time marches on</a> steps in [[HTML]] control the firing of cue
+          events during media playback. <a>Time marches on</a> requires a
           <code>timeupdate</code> event to be fired at the
           <code>HTMLMediaElement</code> between 15 and 250 milliseconds since
           the last such event, and this requirement therefore specifies the rate
-          at which <em>time marches on</em> is executed during playback. In
+          at which <a>time marches on</a> is executed during playback. In
           practice it <a href="https://www.w3.org/2018/12/17-me-minutes.html#item06">has
           been found</a> that the timing varies between browser implementations.
         </p>
@@ -633,19 +643,19 @@
               <code>TextTrack</code> and inspect the track's
               <code>activeCues</code> list. Because <code>activeCues</code>
               contains the list of cues that are active at the time that
-              <em>time marches on</em></a> is run, it is possible for cues to be
+              <a>time marches on</a> is run, it is possible for cues to be
               missed by a web application using this method, where cues appear
               on the <a>media timeline</a> between successive executions of
-              <em>time marches on</em> during media playback. This may occur
+              <a>time marches on</a> during media playback. This may occur
               if the cues have short duration, or by a long-running event
               handler function.
             </li>
             <li>
               Add <code>onenter</code> and <code>onexit</code> handler functions
-              to each cue. The <em>time marches on</em> steps guarantee that
+              to each cue. The <a>time marches on</a> steps guarantee that
               <code>enter</code> and <code>exit</code> events will be fired for
               all cues, including those that appear on the <a>media timeline</a>
-              between successive executions of <em>time marches on</em>
+              between successive executions of <a>time marches on</a>
               during media playback. This method is only possible for cues
               created by the web application, i.e., <code>VTTCue</code> objects,
               and not cue objects created by the user agent.
@@ -669,7 +679,7 @@
           web application to manage the <a>media timed events</a> to be triggered,
           rather than add use the text track cue APIs in [[HTML]]. This has the
           same synchronization limitations as described above, because the 250
-          millisecond update rate specified in <em>time marches on</em> is too
+          millisecond update rate specified in <a>time marches on</a> is too
           infrequent to ensure that the web content can be updated smoothly
           (for example, rendering a playhead position marker in an audio
           waveform visualization), or to occur at specific points on the
@@ -767,8 +777,8 @@
         <h3>Synchronization</h3>
         <p>
           In order to acheive greater synchronization accuracy between media
-          playback and web content rendered by an application, the <em>time
-          marches on</em> steps in [[HTML]] should be modified to allow delivery
+          playback and web content rendered by an application, the <a>time
+          marches on</a> steps in [[HTML]] should be modified to allow delivery
           of <a>media timed event</a> start time and end time notifications within 20
           milliseconds of their positions on the <a>media timeline</a>.
         </p>

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
         events synchronized to audio or video media, specifically for both
         <a>out-of-band</a> event streams and <a>in-band</a> discrete events
         (for example, MPD and <code>emsg</code> events in MPEG-DASH).
-        These <em>media timed events</em> can be used to support use cases
+        These <dfn data-lt="media timed event">media timed events</dfn> can be used to support use cases
         such as dynamic content replacement, ad insertion, or presentation of
         supplemental content alongside the audio or video, or more generally,
         making changes to a web page, or executing application code triggered
@@ -126,7 +126,7 @@
     <section>
       <h2>Use cases</h2>
       <p>
-        Media timed events carry metadata that is related to points in time,
+        <a>Media timed events</a> carry metadata that is related to points in time,
         or regions of time on the <a>media timeline</a>, which can be used to
         trigger retrieval and/or rendering of web resources synchronized with
         media playback. Such resources can be used to enhance user experience
@@ -146,7 +146,7 @@
           A media content provider wants to allow insertion of content,
           such as personalised video, local news, or advertisements,
           into a video media stream that contains the main program content.
-          To achieve this, media timed events used to describe the points
+          To achieve this, <a>media timed events</a> used to describe the points
           on the <a>media timeline</a>, known as splice points, where switching
           playback to inserted content is possible.
         </p>
@@ -178,7 +178,7 @@
       <section>
         <h3>Control messages for media streaming clients</h3>
         <p>
-          A media streaming server uses <a>media timed events<a> to send control
+          A media streaming server uses <a>media timed events</a> to send control
           messages to media client library, such as <a href="https://github.com/Dash-Industry-Forum/dash.js">dash.js</a>.
           Typically segmented streaming protocols such as HLS and MPEG-DASH make
           use of a manifest document that informs the client of the available
@@ -274,7 +274,7 @@
       <h2>Related industry specifications</h2>
       <p>
         This section describes existing media industry specifications and
-        standards that specify carriage of media timed events, or otherwise
+        standards that specify carriage of <a>media timed events</a>, or otherwise
         provide requirements for web APIs related to the triggering of media
         timed events.
       </p>
@@ -311,7 +311,7 @@
           MPEG-2 transport stream.
         </p>
         <p>
-          In MPEG-DASH, media timed events may be delivered either
+          In MPEG-DASH, <a>media timed events</a> may be delivered either
           <a>in-band</a> or <a>out-of-band</a>:
         </p>
         <ul>
@@ -666,7 +666,7 @@
         <p>
           Another approach to synchronizing rendering of web content to media
           playback is to use the <code>timeupdate</code> event, and for the
-          web application to manage the media timed events to be triggered,
+          web application to manage the <a>media timed events</a> to be triggered,
           rather than add use the text track cue APIs in [[HTML]]. This has the
           same synchronization limitations as described above, because the 250
           millisecond update rate specified in <em>time marches on</em> is too
@@ -691,7 +691,7 @@
       <h2>Recommendations</h2>
       <p>
         This section describes recommendations from the Media &amp; Entertainment
-        Interest Group for the development of a generic media timed event API,
+        Interest Group for the development of a generic <a>media timed event</a> API,
         and associated synchronization considerations.
       </p>
       <section>
@@ -728,7 +728,7 @@
         </p>
         <ul>
           <li>
-            Generate a JavaScript event when an <a>in-band</a> media timed event
+            Generate a JavaScript event when an <a>in-band</a> <a>media timed event</a>
             is parsed from the media container or media stream (DAInty Mode 1).
           </li>
           <li>
@@ -749,7 +749,7 @@
         <h3>In-band event processing</h3>
         <p>
           We recommend updating [[INBANDTRACKS]] to describe handling of
-          <a>in-band</a> media timed events supported on the web platform,
+          <a>in-band</a> <a>media timed events</a> supported on the web platform,
           following a registry approach with one specification per media format
           that describes the event details for that format.
         </p>
@@ -769,7 +769,7 @@
           In order to acheive greater synchronization accuracy between media
           playback and web content rendered by an application, the <em>time
           marches on</em> steps in [[HTML]] should be modified to allow delivery
-          of media timed event start time and end time notifications within 20
+          of <a>media timed event</a> start time and end time notifications within 20
           milliseconds of their positions on the <a>media timeline</a>.
         </p>
       </section>


### PR DESCRIPTION
The document tried to reference the definition of "media timed events" but that definition was not marked as being a definition. The update also adds references to the definition from the various sections that use it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/me-media-timed-events/pull/34.html" title="Last updated on Feb 16, 2019, 12:05 PM UTC (c5b84da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-timed-events/34/b64a379...tidoust:c5b84da.html" title="Last updated on Feb 16, 2019, 12:05 PM UTC (c5b84da)">Diff</a>