### PR TITLE
Clarify that time marches on may run at any rate

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,11 @@
         <li>
           <dfn data-cite="HTML/media.html#time-marches-on">time marches on</dfn>
         </li>
+        <li>
+          <dfn data-cite="HTML/media.html#current-playback-position">current
+          playback position</dfn>
+          </dfn>
+        </li>
       </ul>
     </section>
     <section>
@@ -624,13 +629,13 @@
         </p>
         <p>
           The <a>time marches on</a> steps in [[HTML]] control the firing of cue
-          events during media playback. <a>Time marches on</a> requires a
-          <code>timeupdate</code> event to be fired at the
-          <code>HTMLMediaElement</code> between 15 and 250 milliseconds since
-          the last such event, and this requirement therefore specifies the rate
-          at which <a>time marches on</a> is executed during playback. In
-          practice it <a href="https://www.w3.org/2018/12/17-me-minutes.html#item06">has
-          been found</a> that the timing varies between browser implementations.
+          events during media playback. The steps must run whenever the
+          <a>current playback position</a> of a media element changes, but the
+          specification does not require a specific rate at which this needs to
+          happen. In practice it
+          <a href="https://www.w3.org/2018/12/17-me-minutes.html#item06">has
+          been found</a> that the timing varies between browser implementations
+          and may exceed 20 milliseconds.
         </p>
         <p>
           There are two methods a web application can use to handle text track
@@ -676,16 +681,17 @@
         <p>
           Another approach to synchronizing rendering of web content to media
           playback is to use the <code>timeupdate</code> event, and for the
-          web application to manage the <a>media timed events</a> to be triggered,
-          rather than add use the text track cue APIs in [[HTML]]. This has the
-          same synchronization limitations as described above, because the 250
-          millisecond update rate specified in <a>time marches on</a> is too
-          infrequent to ensure that the web content can be updated smoothly
-          (for example, rendering a playhead position marker in an audio
-          waveform visualization), or to occur at specific points on the
-          <a>media timeline</a>. In addition, the timing variability of
-          <code>timeupdate</code> events between browser engines makes them
-          unreliable for the purpose of synchronized rendering of web content.
+          web application to manage the <a>media timed events</a> to be
+          triggered, rather than add use the text track cue APIs in [[HTML]].
+          On top of the synchronization limitations described above, <a>time
+          marches on</a> allows implementations to fire <code>timeupdate</code>
+          events every 250 milliseconds, which is too infrequent to ensure that
+          the web content can be updated smoothly (for example, rendering a
+          playhead position marker in an audio waveform visualization), or to
+          occur at specific points on the <a>media timeline</a>. In addition,
+          the timing variability of <code>timeupdate</code> events between
+          browser engines makes them unreliable for the purpose of synchronized
+          rendering of web content.
         </p>
         <p>
           Synchronization accuracy can be improved by polling the media


### PR DESCRIPTION
The text suggested that HTML requires the time marches on steps and timeupdate events to run and get fired every 250 milliseconds at a minimum. I believe that is incorrect.

HTML does not require a specific rate to run the time marches on steps. The wording used in the time marches on step that talks about `timeupdate` events assumes that the steps run at least 4 times per second, but that is an implicit assumption which is not required anywhere AFAICT. The 250ms upper bound is a suggestion, not a requirement (and the informative note that follows the step is confusing because user agents can fire events at a slower rate in practice).

The only requirements in HTML are:
- "When the current playback position of a media element changes (e.g. due to playback or seeking), the user agent must run the time marches on steps" (see [requirement](https://html.spec.whatwg.org/multipage/media.html#playing-the-media-resource:current-playback-position-13)), which essentially requires the rate at which the time marches on steps run to match the rate at which the current playback position changes; and
- "When a media element is potentially playing [...], its current playback position must increase monotonically at the element's playbackRate units of media time per unit time of the media timeline's clock" (see [requirement](https://html.spec.whatwg.org/multipage/media.html#playing-the-media-resource:current-playback-position-9)), which sets the speed at which the current playback position increases, but not the rate at which it gets updated.

New text clarifies that the issue is that implementations are only required to run the time marches on steps when the current playback position changes, and that they are basically free to do that at any rate. On top of that, the time marches on steps allow timeupdate events to be fired only every 250ms, which makes the mechanism unsuitable for synchronized rendering. The HTML spec explicitly [discourages the use of `timeupdate` events for processing cues](https://html.spec.whatwg.org/multipage/media.html#best-practices-for-metadata-text-tracks:event-media-timeupdate)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/me-media-timed-events/pull/35.html" title="Last updated on Feb 16, 2019, 1:02 PM UTC (607602a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-timed-events/35/f5a1428...tidoust:607602a.html" title="Last updated on Feb 16, 2019, 1:02 PM UTC (607602a)">Diff</a>