### PR TITLE
Change giris affiliation

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,9 +16,12 @@
             company: "British Broadcasting Corporation",
             companyURL: "https://www.bbc.co.uk"
           },
+        ],
+        formerEditors: [
           {
             name: "Giridhar Mandyam",
-            note: "Former Editor, until December 2018 while at Qualcomm"
+            company: "Qualcomm",
+            note: "until December 2018"
           }
         ],
         wg: "Media & Entertainment Interest Group",

--- a/index.html
+++ b/index.html
@@ -18,9 +18,7 @@
           },
           {
             name: "Giridhar Mandyam",
-            mailto: "mandyam@qti.qualcomm.com",
-            company: "Qualcomm",
-            companyURL: "https://www.qualcomm.com"
+            note: "Former Editor, while at Qualcomm"
           }
         ],
         wg: "Media & Entertainment Interest Group",

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
           },
           {
             name: "Giridhar Mandyam",
-            note: "Former Editor, while at Qualcomm"
+            note: "Former Editor, until December 2018 while at Qualcomm"
           }
         ],
         wg: "Media & Entertainment Interest Group",


### PR DESCRIPTION
As I did for the [publication preparation snapshot](https://w3c.github.io/me-media-timed-events/publication/fpin/), we need to update Giri's affiliation information under the Editors section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-timed-events/pull/45.html" title="Last updated on May 7, 2019, 11:40 AM UTC (88c9eac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-timed-events/45/08edf6d...88c9eac.html" title="Last updated on May 7, 2019, 11:40 AM UTC (88c9eac)">Diff</a>