### PR TITLE
Add unbounded media timed events to gap analysis and recommendations

### DIFF
--- a/index.html
+++ b/index.html
@@ -910,7 +910,7 @@
         </p>
       </section>
       <section>
-        <h3>Media timed events with unbounded duration</h3>
+        <h3>Cues with unbounded duration</h3>
         <p>
           To support cues with unknown end time, where the cue is active from
           its start time to the end of the media stream, we recommend that
@@ -925,8 +925,8 @@
           changed. This includes the ability to change an end time from a known
           time on the media timeline to an unknown time, and vice versa, as
           described <a href="#media-timed-events-with-unbounded-duration">above</a>.
-          The user agent should generate a JavaScript event to notify the web
-          application of the change.
+          The user agent should generate events as appropriate to notify the web
+          application of such changes.
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -919,15 +919,13 @@
         </p>
       </section>
       <section>
-        <h3>Updating event times</h3>
+        <h3>Updating media timed events</h3>
         <p>
-          The API should allow a cue's position on the media timeline to be
-          changed. This includes the ability to change an end time from a known
-          time on the media timeline to an unknown time, and vice versa, as
-          described <a href="#media-timed-events-with-unbounded-duration">above</a>.
-          The user agent should generate events as appropriate to notify the web
-          application of such changes.
-        </p>
+          We recommend that the API allows <a>media timed event</a> information
+          to be updated, such as an event's position on the media timeline,
+          and its data payload. Where the <a>media timed event</a> is updated
+          by the user agent, such as for <a>in-band</a> events, we recommend that
+          the API allows the web application to be notified of any changes.
       </section>
       <section>
         <h3>Synchronization</h3>

--- a/index.html
+++ b/index.html
@@ -655,6 +655,21 @@
         </p>
       </section>
       <section>
+        <h3><a>TextTrackCue</a>s with unbounded duration</h3>
+        <p>
+          It is not currently possible to create a <a>TextTrackCue</a> that
+          extends from a given start time to the end of a live media stream. If
+          the stream duration is known, the content author can set the cue's
+          <code>endTime</code> equal to the media duration. However, for live
+          media streams, where the duration is unbounded, it would be useful to
+          allow content authors to specify that the <a>TextTrackCue</a> duration
+          is also unbounded, e.g., by allowing the <code>endTime</code> to be
+          set to <code>Infinity</code>. This would be consistent with the
+          <a>media element</a>'s <code>duration</code> property, which can be
+          <code>Infinity</code> for unbounded streams.
+        </p>
+      </section>
+      <section>
         <h3>Synchronized rendering of web resources</h3>
         <p>
           In browsers, non media web rendering is handled through repaint
@@ -892,6 +907,16 @@
           <a>in-band</a> events and MPD <a>out-of-band</a> events, as part of
           their support for the MPEG Common Media Application Format (CMAF)
           [[MPEGCMAF]].
+        </p>
+      </section>
+      <section>
+        <h3>Media timed events with unbounded duration</h3>
+        <p>
+          To support cues with unknown end time, where the cue is active from
+          its start time to the end of the media stream, we recommend that
+          the <a>TextTrackCue</a> interface be modified to allow the cue
+          duration to be unbounded. It should also be possible to update the
+          cue's end time, should the end time subsequently become known.
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -915,8 +915,18 @@
           To support cues with unknown end time, where the cue is active from
           its start time to the end of the media stream, we recommend that
           the <a>TextTrackCue</a> interface be modified to allow the cue
-          duration to be unbounded. It should also be possible to update the
-          cue's end time, should the end time subsequently become known.
+          duration to be unbounded.
+        </p>
+      </section>
+      <section>
+        <h3>Updating event times</h3>
+        <p>
+          The API should allow a cue's position on the media timeline to be
+          changed. This includes the ability to change an end time from a known
+          time on the media timeline to an unknown time, and vice versa, as
+          described <a href="#media-timed-events-with-unbounded-duration">above</a>.
+          The user agent should generate a JavaScript event to notify the web
+          application of the change.
         </p>
       </section>
       <section>


### PR DESCRIPTION
See #39


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-timed-events/pull/46.html" title="Last updated on Apr 1, 2020, 2:24 PM UTC (749274e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-timed-events/46/5ebcc6e...749274e.html" title="Last updated on Apr 1, 2020, 2:24 PM UTC (749274e)">Diff</a>