### PR TITLE
Add detail of HLS metadata events

### DIFF
--- a/index.html
+++ b/index.html
@@ -418,7 +418,7 @@
           <li>
             HLS supports delivery of ID3 timed metadata carried <a>in-band</a>
             within MPEG-2 Transport Streams [[HLS-TIMED-METADATA]]. ID3 metadata
-            is stored as a complete ID3v4 frame in an elementary stream (PES)
+            is stored as a complete ID3v2.4 frame in an elementary stream (PES)
             packet, including a complete ID3 header [[ID3v2]].
           </li>
           <li>

--- a/index.html
+++ b/index.html
@@ -394,6 +394,7 @@
           as specified in [[MPEGDASH]], section 5.10.3.3:
         </p>
         <ul>
+          <li><code>id</code> &mdash; Event message identifier</li>
           <li><code>scheme_id_uri</code> &mdash; A URI that identifies
           the message scheme</li>
           <li><code>value</code> &mdash; The event value (string)</li>
@@ -404,8 +405,40 @@
           in <code>timescale</code> units</li>
           <li><code>event_duration</code> &mdash; Event duration,
           in <code>timescale</code> units</li>
-          <li><code>id</code> &mdash; Event message identifier</li>
           <li><code>message_data</code> &mdash; Message body (may be empty)</li>
+        </ul>
+      </section>
+      <section>
+        <h3>HTTP Live Streaming</h3>
+        <p>
+          HTTP Live Streaming (HLS) allows for delivery of timed metadata
+          events, both <a>in-band</a> and <a>out-of-band</a>:
+        </p>
+        <ul>
+          <li>
+            HLS supports delivery of ID3 timed metadata carried <a>in-band</a>
+            within MPEG-2 Transport Streams [[HLS-TIMED-METADATA]]. ID3 metadata
+            is stored as a complete ID3v4 frame in an elementary stream (PES)
+            packet, including a complete ID3 header [[ID3v2]].
+          </li>
+          <li>
+            <a>Out-of-band</a> events are delivered using the
+            <code>EXT-X-DATERANGE</code> tag in a HLS playlist file.
+          </li>
+        </ul>
+        <p>
+          An <code>EXT-X-DATERANGE</code> tag contains the following information, as specified in
+          [[RFC8216]], section 4.3.2.7:
+        </p>
+        <ul>
+          <li><code>ID</code> &mdash; Unique event identifier</li>
+          <li><code>CLASS</code> &mdash; An identifier that indicates the event semantics. All events with the same <code>CLASS</code> have the same semantics</li>
+          <li><code>START-DATE</code> &mdash; The date and time of the start of the event</li>
+          <li><code>END-DATE</code> &mdash; The date and time of the end of the event (optional)</li>
+          <li><code>DURATION</code> &mdash; Event duration, in seconds (optional). May be zero</li>
+          <li><code>PLANNED-DURATION</code> &mdash; Expected event duration, where the actual duration is not yet known (optional)</li>
+          <li><code>END-ON-NEXT</code> &mdash; Indicates that the event automatically ends when the next event of the same <code>CLASS</code> starts. If present, this attribute replaces <code>END-DATE</code> and <code>DURATION</code></li>
+          <li><code>X-&lt;client-attribute&gt;</code> &mdash; Allows the application to define its own key/value metadata pairs</li>
         </ul>
       </section>
       <section>
@@ -491,6 +524,12 @@
           [[SCTE214-2]] section 9 and [[SCTE214-3]] section 7.3 describe
           the carriage of SCTE-35 events as <a>in-band</a> events in MPEG-DASH
           using MPEG2-TS and ISO BMFF respectively, using <code>emsg</code>.
+        </p>
+        <p>
+          [[RFC8216]] section 4.3.2.7.1 specifies how to map SCTE-35 events into
+          HLS timed metadata, using the <code>EXT-X-DATERANGE</code> tag, with
+          <code>SCTE35-CMD</code>, <code>SCTE35-OUT</code>, and
+          <code>SCTE35-IN</code> attributes.
         </p>
           [[SCTE35]] section 9.1 describes the requirements for content
           splicing: "In order to give advance warning of the impending splice


### PR DESCRIPTION
Addresses #43. @jernoble, please take a look. I have one question: Section 2.4 [here](https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/HTTP_Live_Streaming_Metadata_Spec/2/2.html#//apple_ref/doc/uid/TP40010435-CH2-DontLinkElementID_7) mentions "ID3v4 frame". Is this [ID3v2.4](http://id3.org/id3v2.4.0-structure)?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-timed-events/pull/47.html" title="Last updated on May 30, 2019, 8:46 AM UTC (2fcc424)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-timed-events/47/4a6592c...2fcc424.html" title="Last updated on May 30, 2019, 8:46 AM UTC (2fcc424)">Diff</a>