### PR TITLE
Live event use case

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,6 +317,40 @@
         </p>
       </section>
       <section>
+        <h3>Live event coverage</h3>
+        <p>
+          Media content providers often cover live events where the timing
+          of particular segments, although often pre-scheduled, can be subject
+          to last minute change, or may not be known ahead of time.
+        </p>
+        <p>
+          The media content provider uses media timed events together with their
+          video stream to add metadata to annotate the start and (where known)
+          end times of each of these segments. This metadata drives a user
+          interface that allows users to see information about the current
+          playing and upcoming segments.
+        </p>
+        <p>
+          Examples of the dynamic nature of the timing include:
+        </p>
+        <ul>
+          <li>
+            A baseball game, where the total duration is not known in advance,
+            but after the game ends is followed by a period of known
+            duration for post-game interviews.
+          </li>
+          <li>
+            An award show, which is scheduled for a given duration, runs over
+            time and so the exact end time becomes unknown.
+          </li>
+          <li>
+            A regularly scheduled one-hour news program, which is extended by
+            30 minutes to cover a breaking news story, or is cut short for
+            an unscheduled government announcement.
+          </li>
+        </ul>
+      </section>
+      <section>
         <h3>Presentation of auxiliary content in live media</h3>
         <p>
           During a live media presentation, dynamic and unpredictable events

--- a/index.html
+++ b/index.html
@@ -639,6 +639,12 @@
           could be avoided.
         </p>
         <p>
+          Avoiding parsing in JavaScript is also important for low latency
+          video streaming applications, where minimizing the time taken to pass
+          media content through to the media element's playback buffer is
+          essential.
+        </p>
+        <p>
           [[HBBTV]] section 9.3.2 describes a mapping between the <code>emsg</code>
           fields described <a href="#mpeg-dash">above</a>
           and the <a>TextTrack</a>


### PR DESCRIPTION
Following comment from @mavgit in https://github.com/w3c/me-media-timed-events/issues/39#issuecomment-494596204, this PR adds a new use case to illustrate the need for changing event timings, as well as events where the end time is initially unknown and subsequently becomes defined.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-timed-events/pull/48.html" title="Last updated on Jun 3, 2019, 10:16 AM UTC (d47a8c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-timed-events/48/b4bce82...d47a8c3.html" title="Last updated on Jun 3, 2019, 10:16 AM UTC (d47a8c3)">Diff</a>