### PR TITLE
Update Carriage of Web Resources in ISO BMFF reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,16 +32,6 @@
           branch: "master"
         },
         localBiblio: {
-          "WEB-ISOBMFF": {
-            title: "ISO/IEC JTC1/SC29/WG11 N16944 Working Draft on Carriage of Web Resources in ISOBMFF",
-            href: "https://mpeg.chiariglione.org/standards/mpeg-4/timed-text-and-other-visual-overlays-iso-base-media-file-format/wd-carriage-web",
-            authors: [
-              "Thomas Stockhammer",
-              "Cyril Concolato"
-            ],
-            publisher: "MPEG",
-            date: "July 2017",
-          },
           "DASH-EVENTING": {
             title: "DASH Eventing and HTML5",
             href: "https://www.w3.org/2011/webtv/wiki/images/a/a5/DASH_Eventing_and_HTML5.pdf",
@@ -628,12 +618,11 @@
         </p>
       </section>
       <section>
-        <h3>MPEG Working Draft on Carriage of Web Resources in ISO BMFF</h3>
+        <h3>MPEG Carriage of Web Resources in ISO BMFF</h3>
         <p>
-          The MPEG Working Draft on Carriage of Web Resources in ISO BMFF
-          [[WEB-ISOBMFF]] is a draft document that specifies the use of the
-          ISO BMFF container format for the storage and delivery of web
-          content. The goal is to allow web resources (HTML, JavaScript, etc.)
+          MPEG Carriage of Web Resources in ISO BMFF [[iso23001-15]] specifies
+          the use of the ISO BMFF container format for the storage and delivery
+          of web content. The goal is to allow web resources (HTML, CSS, etc.)
           to be parsed from the storage and processed by a user agent at
           specific presentation times on the <a>media timeline</a>, and so be
           synchronized with other tracks within the container, such as audio,


### PR DESCRIPTION
This document is now a [published ISO/IEC standard][1].

[1]: https://www.iso.org/standard/75492.html
