### PR TITLE
Add reference to AOM's ID3 in emsg spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,14 +33,14 @@
         },
         localBiblio: {
           "ID3-EMSG": {
-            title: "Timed Metadata in the Common Media Application Format (CMAF)",
+            title: "Carriage of ID3 Timed Metadata in the Common Media Application Format (CMAF)",
             href: "https://aomediacodec.github.io/id3-emsg/",
             authors: [
               "Krasimir Kolarov",
               "John Simmons"
             ],
             publisher: "AOM",
-            date: "25 June 2019"
+            date: "12 March 2020"
           },
           "DASH-EVENTING": {
             title: "DASH Eventing and HTML5",

--- a/index.html
+++ b/index.html
@@ -32,6 +32,16 @@
           branch: "master"
         },
         localBiblio: {
+          "ID3-EMSG": {
+            title: "Timed Metadata in the Common Media Application Format (CMAF)",
+            href: "https://aomediacodec.github.io/id3-emsg/",
+            authors: [
+              "Krasimir Kolarov",
+              "John Simmons"
+            ],
+            publisher: "AOM",
+            date: "25 June 2019"
+          },
           "DASH-EVENTING": {
             title: "DASH Eventing and HTML5",
             href: "https://www.w3.org/2011/webtv/wiki/images/a/a5/DASH_Eventing_and_HTML5.pdf",
@@ -509,6 +519,11 @@
           <li><code>END-ON-NEXT</code> &mdash; Indicates that the event automatically ends when the next event of the same <code>CLASS</code> starts. If present, this attribute replaces <code>END-DATE</code> and <code>DURATION</code></li>
           <li><code>X-&lt;client-attribute&gt;</code> &mdash; Allows the application to define its own key/value metadata pairs</li>
         </ul>
+        <p>
+          For interoperability between HLS and CMAF, The Alliance for Open Media
+          has published [[ID3-EMSG]], which specifies how to include ID3 metadata
+          in <code>emsg</code> boxes.
+        </p>
       </section>
       <section>
         <h3>HbbTV</h3>


### PR DESCRIPTION
This PR adds a reference to the AOM [Timed Metadata in the Common Media Application Format (CMAF)][1] spec.

We'll wait to merge this as the document has some editorial PRs open, including a change to the title.

[1]: https://aomediacodec.github.io/id3-emsg/


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 140222018242432:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 16, 2020, 2:12 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fme-media-timed-events%2Fpull%2F54%2Ffe68c25.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fme-media-timed-events%2Fpull%2F54.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/me-media-timed-events%2354.)._
</details>
