### PR TITLE
Update link to disclosure section in charter

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         ],
         wg: "Media & Entertainment Interest Group",
         wgURI: "https://www.w3.org/2011/webtv/",
-        charterDisclosureURI: "https://www.w3.org/2017/03/webtv-charter.html",
+        charterDisclosureURI: "https://www.w3.org/2019/06/me-ig-charter.html#patentpolicy",
         github: {
           repoURL: "https://github.com/w3c/me-media-timed-events/",
           branch: "master"


### PR DESCRIPTION
The URL was pointing at the previous charter. Also, publication rules require that the link be to the discoluse section of the group charter:
https://www.w3.org/pubrules/doc/rules/?profile=IG-NOTE#patPolReq


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/me-media-timed-events/pull/57.html" title="Last updated on Apr 7, 2020, 9:19 AM UTC (f73ecc5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-timed-events/57/4405cdc...tidoust:f73ecc5.html" title="Last updated on Apr 7, 2020, 9:19 AM UTC (f73ecc5)">Diff</a>